### PR TITLE
Fix a potential git security issue

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,7 @@ git checkout master
 git status
 git remote add backup ${TARGET_GIT}
 git remote -vv
+git config --global --add safe.directory /github/workspace
 git config --global user.name "${GITHUB_ACTOR}"
 git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 echo 'ready to push'


### PR DESCRIPTION
see also the following output:
```shell
git version 2.34.2
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
```